### PR TITLE
Update for public SDK

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
                 "output": {
                   "type": "string",
                   "description": "Path to the root of your outputs.",
-                  "default": "${workspaceFolder}/Output"
+                  "default": "${workspaceFolder}/Output.pdx"
                 }
               }
             }

--- a/src/MockDebugSession.ts
+++ b/src/MockDebugSession.ts
@@ -1,7 +1,6 @@
 import { LoggingDebugSession, TerminatedEvent } from "vscode-debugadapter";
 import { spawnSync } from "child_process";
 import { DebugProtocol } from "vscode-debugprotocol";
-import { join } from "path";
 
 interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
   source: string;
@@ -11,7 +10,7 @@ interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
 export class MockDebugSession extends LoggingDebugSession {
   protected async launchRequest(response: DebugProtocol.LaunchResponse, args: LaunchRequestArguments) {
     // Open the Sim, and then close this debugger
-    spawnSync("open", [join(args.output, "main.pdx")]);
+    spawnSync("open", [args.output]);
     this.sendEvent(new TerminatedEvent());
   }
 }


### PR DESCRIPTION
In the current version of the SDK, the `pdc` output directory is named `<Something>.pdx` and can be opened with the simulator, opening `main.pdz` doesn't work