### PR TITLE
Add support to launch simulator on Windows

### DIFF
--- a/src/MockDebugSession.ts
+++ b/src/MockDebugSession.ts
@@ -10,7 +10,24 @@ interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
 export class MockDebugSession extends LoggingDebugSession {
   protected async launchRequest(response: DebugProtocol.LaunchResponse, args: LaunchRequestArguments) {
     // Open the Sim, and then close this debugger
-    spawnSync("open", [args.output]);
+    var cmd: string;
+    var spawnArgs: string[];
+
+    switch (process.platform) {
+      case "win32":
+        cmd = "cmd";
+        spawnArgs = ["/c", "start", `${args.output}/main.pdz`];
+        break;
+      case "darwin":
+        cmd = "open";
+        spawnArgs = [args.output];
+        break;
+      default:
+        console.log("os not supported");
+        return;
+    }
+
+    spawnSync(cmd, spawnArgs);
     this.sendEvent(new TerminatedEvent());
   }
 }


### PR DESCRIPTION
This will use `process.platform` and spawn different commands based on OS (only supports Windows and macOS).

On macOS this will still just open the `.pdx` output like before (`open Output.pdx`).

On Windows this will use `cmd` to start a shell and use the `start` command to run the `pdz` file that exist inside the `Output.pdx` package (which looks like a folder in Windows).

Tested this on a very simple project with some external resources (fonts) on Windows 11 and macOS 12.2.