### PR TITLE
Don't use `open` to launch simulator in default case

### DIFF
--- a/src/playdate.ts
+++ b/src/playdate.ts
@@ -30,7 +30,7 @@ export function runSimulator(
       return spawnSync("open", [simulator, output]);
     default:
       var simulator = `${sdkPath}/bin/PlaydateSimulator`;
-      return spawnSync("open", [simulator, output]);
+      return spawnSync(simulator, [output]);
   }
 
   return null;


### PR DESCRIPTION
With this last commit (now that  #19 has fixed the other issue) I can now actually launch the simulator from the IDE.

And #15 is complete.