### PR TITLE
Remove duplicate `contributes` section

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
         "title": "Run app in Playdate simulator"
       }
     ],
-    "contributes": {
-      "configuration": {
+    "configuration": [
+      {
         "id": "vscode-playdate",
         "title": "Playdate",
         "properties": {
@@ -47,7 +47,7 @@
           }
         }
       }
-    },
+    ],
     "debuggers": [
       {
         "type": "playdate",


### PR DESCRIPTION
Remove faulty configuration in `package.json` so VS Code will recognize
the settings and support autocomplete, defaults and description.

Closes #23